### PR TITLE
Add new History tests

### DIFF
--- a/backend/src/src/models/statistics.model.ts
+++ b/backend/src/src/models/statistics.model.ts
@@ -3,13 +3,13 @@ import SongModel from "./song.model";
 import UserModel from "./user.model";
 
 export default class StatisticsModel {
-  most_played_song_name?: string;
-  most_played_genre_name?: string;
-  play_duration?: number;
+  most_played_song?: string;
+  most_played_genre?: string;
+  time_played?: number;
 
   constructor(data: StatisticsModel) {
-    this.most_played_song_name = data.most_played_song_name;
-    this.most_played_genre_name = data.most_played_genre_name;
-    this.play_duration = data.play_duration;
+    this.most_played_song = data.most_played_song;
+    this.most_played_genre = data.most_played_genre;
+    this.time_played = data.time_played;
   }
 }

--- a/backend/src/src/services/history.service.ts
+++ b/backend/src/src/services/history.service.ts
@@ -126,9 +126,9 @@ class HistoryService {
     }
 
     return new StatisticsModel({
-      most_played_genre_name: mostPlayedGenre,
-      most_played_song_name: mostPlayedSong?.song_name,
-      play_duration: totalDuration,
+      most_played_genre: mostPlayedGenre,
+      most_played_song: mostPlayedSong?.song_name,
+      time_played: totalDuration,
     });
   }
 

--- a/backend/src/tests/features/history-route.feature
+++ b/backend/src/tests/features/history-route.feature
@@ -1,8 +1,8 @@
 Feature: History Routes
 
-# API
-Scenario: Create a test
-    Given o TestRepository não tem um test com nome "test"
-    When uma requisição POST for enviada para "/api/tests" com o corpo da requisição sendo um JSON com o nome "test"
-    Then o status da resposta deve ser "200"
-    And o JSON da resposta deve conter o nome "test" 
+    # API
+    Scenario: Create a test
+        Given o TestRepository não tem um test com nome "test"
+        When uma requisição POST for enviada para "/api/tests" com o corpo da requisição sendo um JSON com o nome "test"
+        Then o status da resposta deve ser "200"
+        And o JSON da resposta deve conter o nome "test"

--- a/backend/src/tests/features/history-service.feature
+++ b/backend/src/tests/features/history-service.feature
@@ -5,3 +5,29 @@ Scenario: Obter histórico de um usuário por id
     Given o método getUserHistory chamado com "1" do HistoryService retorna um histórico com "3" itens com song_id "1", "2" e "3"
     When o método getUserHistory do HistoryService for chamado com o id "1"
     Then o histórico retornado deve ter "3" itens com song_id "1", "2" e "3"
+
+Scenario: Add a new song to an user history
+    Given the function createHistory was called with the user_id "1" and the song_id "4"
+    When the function getUserHistory is called with the user_id "1"
+    Then the history returned must have "1" item with song_id "4"
+
+Scenario: Delete an entry from an user history
+    Given the user with id "1" has a history entry with id "abc"
+    When the function deleteHistory is called with id "abc"
+    And the function getUserHistory is called with the user_id "1"
+    Then the history returned must not have the entry with id "abc"
+
+Scenario: Clear user history
+    Given the user with id "1" has a history with "3" items
+    When the function deleteUserHistory is called with the user_id "1"
+    Then the history returned must have "0" items
+
+Scenario: Get user statistics
+    Given the user with id "1" has a history with the following items:
+    | times_played | song_id | title | artist | genre | duration |
+    | 3            | 1       | Never Gonna Give You Up | Rick Astley | Rock | 300 |
+    | 1            | 2       | Yellow Submarine | The Beatles | Rock | 100 |
+    When the function getUserStatistics is called with the user_id "1"
+    Then it must return the following statistics:
+    | most_played_song | most_played_genre | play_duration |
+    | Never Gonna Give You Up | Rock | 1000 |

--- a/backend/src/tests/features/history-service.feature
+++ b/backend/src/tests/features/history-service.feature
@@ -12,10 +12,11 @@ Feature: History Service
         Then the history returned must have "1" item with song_id "4"
 
     Scenario: Delete an entry from an user history
-        Given the user with id "1" has a history entry with id "abc"
-        When the function deleteHistory is called with id "abc"
+        Given the user with id "1" has 3 history entries
+        When the function deleteHistory is called on one of the entry ids
         And the function getUserHistory is called with the user_id "1"
-        Then the history returned must not have the entry with id "abc"
+        Then the history returned must not have the entry that was deleted
+        And the user history must have 2 entries
 
     Scenario: Clear user history
         Given the user with id "1" has a history with "3" items

--- a/backend/src/tests/features/history-service.feature
+++ b/backend/src/tests/features/history-service.feature
@@ -19,9 +19,10 @@ Feature: History Service
         And the user history must have 2 entries
 
     Scenario: Clear user history
-        Given the user with id "1" has a history with "3" items
+        Given the user with id "1" has 3 history entries
         When the function deleteUserHistory is called with the user_id "1"
-        Then the history returned must have "0" items
+        And the function getUserHistory is called with the user_id "1"
+        Then the history returned must have 0 items
 
     Scenario: Get user statistics
         Given the user with id "1" has a history with the following items:

--- a/backend/src/tests/features/history-service.feature
+++ b/backend/src/tests/features/history-service.feature
@@ -6,12 +6,12 @@ Feature: History Service
         When o método getUserHistory do HistoryService for chamado com o id "1"
         Then o histórico retornado deve ter "3" itens com song_id "1", "2" e "3"
 
-    Scenario: Add a new song to an user history
+    Scenario: Add a new song to a user history
         Given the function createHistory was called with the user_id "1" and the song_id "4"
         When the function getUserHistory is called with the user_id "1"
         Then the history returned must have "1" item with song_id "4"
 
-    Scenario: Delete an entry from an user history
+    Scenario: Delete an entry from a user history
         Given the user with id "1" has 3 history entries
         When the function deleteHistory is called on one of the entry ids
         And the function getUserHistory is called with the user_id "1"

--- a/backend/src/tests/features/history-service.feature
+++ b/backend/src/tests/features/history-service.feature
@@ -1,33 +1,33 @@
 Feature: History Service
 
-# Service
-Scenario: Obter histórico de um usuário por id
-    Given o método getUserHistory chamado com "1" do HistoryService retorna um histórico com "3" itens com song_id "1", "2" e "3"
-    When o método getUserHistory do HistoryService for chamado com o id "1"
-    Then o histórico retornado deve ter "3" itens com song_id "1", "2" e "3"
+    # Service
+    Scenario: Obter histórico de um usuário por id
+        Given o método getUserHistory chamado com "1" do HistoryService retorna um histórico com "3" itens com song_id "1", "2" e "3"
+        When o método getUserHistory do HistoryService for chamado com o id "1"
+        Then o histórico retornado deve ter "3" itens com song_id "1", "2" e "3"
 
-Scenario: Add a new song to an user history
-    Given the function createHistory was called with the user_id "1" and the song_id "4"
-    When the function getUserHistory is called with the user_id "1"
-    Then the history returned must have "1" item with song_id "4"
+    Scenario: Add a new song to an user history
+        Given the function createHistory was called with the user_id "1" and the song_id "4"
+        When the function getUserHistory is called with the user_id "1"
+        Then the history returned must have "1" item with song_id "4"
 
-Scenario: Delete an entry from an user history
-    Given the user with id "1" has a history entry with id "abc"
-    When the function deleteHistory is called with id "abc"
-    And the function getUserHistory is called with the user_id "1"
-    Then the history returned must not have the entry with id "abc"
+    Scenario: Delete an entry from an user history
+        Given the user with id "1" has a history entry with id "abc"
+        When the function deleteHistory is called with id "abc"
+        And the function getUserHistory is called with the user_id "1"
+        Then the history returned must not have the entry with id "abc"
 
-Scenario: Clear user history
-    Given the user with id "1" has a history with "3" items
-    When the function deleteUserHistory is called with the user_id "1"
-    Then the history returned must have "0" items
+    Scenario: Clear user history
+        Given the user with id "1" has a history with "3" items
+        When the function deleteUserHistory is called with the user_id "1"
+        Then the history returned must have "0" items
 
-Scenario: Get user statistics
-    Given the user with id "1" has a history with the following items:
-    | times_played | song_id | title | artist | genre | duration |
-    | 3            | 1       | Never Gonna Give You Up | Rick Astley | Rock | 300 |
-    | 1            | 2       | Yellow Submarine | The Beatles | Rock | 100 |
-    When the function getUserStatistics is called with the user_id "1"
-    Then it must return the following statistics:
-    | most_played_song | most_played_genre | play_duration |
-    | Never Gonna Give You Up | Rock | 1000 |
+    Scenario: Get user statistics
+        Given the user with id "1" has a history with the following items:
+            | times_played | song_id | title                   | artist      | genre | duration |
+            | 3            | 1       | Never Gonna Give You Up | Rick Astley | Rock  | 300      |
+            | 1            | 2       | Yellow Submarine        | The Beatles | Rock  | 100      |
+        When the function getUserStatistics is called with the user_id "1"
+        Then it must return the following statistics:
+            | most_played_song        | most_played_genre | play_duration |
+            | Never Gonna Give You Up | Rock              | 1000          |

--- a/backend/src/tests/services/history.service.steps.ts
+++ b/backend/src/tests/services/history.service.steps.ts
@@ -290,13 +290,10 @@ defineFeature(feature, (test) => {
     );
 
     then("it must return the following statistics:", (table) => {
-      console.debug(table[0])
-      console.debug(userStatistics)
-
       let expected = new StatisticsModel({
-        play_duration: parseInt(table[0].play_duration),
-        most_played_genre_name: table[0].most_played_genre,
-        most_played_song_name: table[0].most_played_song,
+        time_played: parseInt(table[0].play_duration),
+        most_played_genre: table[0].most_played_genre,
+        most_played_song: table[0].most_played_song,
       });
 
       expect(userStatistics).toEqual(expected);

--- a/backend/src/tests/services/history.service.steps.ts
+++ b/backend/src/tests/services/history.service.steps.ts
@@ -75,14 +75,14 @@ defineFeature(feature, (test) => {
             song_id: song,
           });
           await historyService.createHistory(mockHistoryEntity);
-        }        
+        }
       }
     );
 
     when(
       /^o método getUserHistory do HistoryService for chamado com o id "(.*)"$/,
       async (user_id) => {
-      result = await historyService.getUserHistory(user_id);
+        result = await historyService.getUserHistory(user_id);
       }
     );
 
@@ -95,6 +95,92 @@ defineFeature(feature, (test) => {
         }
       }
     );
+  });
+
+  test("Add a new song to an user history", ({ given, when, then }) => {
+    let result: HistoryModel[] = [];
+    given(
+      /^the function createHistory was called with the user_id "(.*)" and the song_id "(.*)"$/,
+      async (user_id, song_id) => {
+        mockHistoryEntity = new HistoryEntity({
+          id: "",
+          user_id: user_id,
+          song_id: song_id,
+        });
+
+        jest.spyOn(mockHistoryRepository, "createHistory");
+
+        await historyService.createHistory(mockHistoryEntity);
+
+        expect(mockHistoryRepository.createHistory).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    when(
+      /^the function getUserHistory is called with the user_id "(.*)"$/,
+      async (user_id) => {
+        jest.spyOn(mockHistoryRepository, "getHistories");
+
+        result = await historyService.getUserHistory(user_id);
+
+        expect(mockHistoryRepository.getHistories).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    then(
+      /^the history returned must have "(.*)" item with song_id "(.*)"$/,
+      (num_items, song_id) => {
+        expect(result.length).toBe(parseInt(num_items));
+        expect(result[0].song_id).toBe(song_id);
+      }
+    );
+  });
+
+  test("Delete an entry from an user history", ({ given, when, and, then }) => {
+    given(
+      /^the user with id "(.*)" has a history entry with id "(.*)"$/,
+      (arg0, arg1) => {}
+    );
+
+    when(/^the function deleteHistory is called with id "(.*)"$/, (arg0) => {});
+
+    and(
+      /^the function getUserHistory is called with the user_id "(.*)"$/,
+      (arg0) => {}
+    );
+
+    then(
+      /^the history returned must not have the entry with id "(.*)"$/,
+      (arg0) => {}
+    );
+  });
+
+  test("Clear user history", ({ given, when, then }) => {
+    given(
+      /^the user with id "(.*)" has a history with "(.*)" items$/,
+      (arg0, arg1) => {}
+    );
+
+    when(
+      /^the function deleteUserHistory is called with the user_id "(.*)"$/,
+      (arg0) => {}
+    );
+
+    then(/^the history returned must have "(.*)" items$/, (arg0) => {});
+  });
+
+  test("Get user statistics", ({ given, when, then }) => {
+    given(
+      /^the user with id "(.*)" has a history with the following items:$/,
+      (arg0, table) => {}
+    );
+
+    when(
+      /^the function getUserStatistics is called with the user_id "(.*)"$/,
+      (arg0) => {}
+    );
+
+    then("it must return the following statistics:", (table) => {});
   });
 });
 

--- a/backend/src/tests/services/history.service.steps.ts
+++ b/backend/src/tests/services/history.service.steps.ts
@@ -98,7 +98,7 @@ defineFeature(feature, (test) => {
     );
   });
 
-  test("Add a new song to an user history", ({ given, when, then }) => {
+  test("Add a new song to a user history", ({ given, when, then }) => {
     let result: HistoryModel[] = [];
     given(
       /^the function createHistory was called with the user_id "(.*)" and the song_id "(.*)"$/,
@@ -137,7 +137,7 @@ defineFeature(feature, (test) => {
     );
   });
 
-  test("Delete an entry from an user history", ({ given, when, and, then }) => {
+  test("Delete an entry from a user history", ({ given, when, and, then }) => {
     let deleted_entry: HistoryModel;
     given(
       /^the user with id "(.*)" has (\d+) history entries$/,
@@ -241,7 +241,7 @@ defineFeature(feature, (test) => {
   test("Get user statistics", ({ given, when, then }) => {
     given(
       /^the user with id "(.*)" has a history with the following items:$/,
-      async (user_id, table) => {        
+      async (user_id, table) => {
         // create songs and entries
         jest.spyOn(mockHistoryRepository, "createHistory");
         jest.spyOn(mockSongRepository, "createSong");
@@ -269,10 +269,15 @@ defineFeature(feature, (test) => {
             await historyService.createHistory(mockHistoryEntity);
           }
         }
-        expect(mockSongRepository.createSong).toHaveBeenCalledTimes(table.length);
+        expect(mockSongRepository.createSong).toHaveBeenCalledTimes(
+          table.length
+        );
 
         // total_songs added should be equal to the sum of each entry on table.times_played
-        let total_songs_added = table.reduce((counter: number, row: any) => counter + parseInt(row.times_played), 0);
+        let total_songs_added = table.reduce(
+          (counter: number, row: any) => counter + parseInt(row.times_played),
+          0
+        );
 
         expect(mockHistoryRepository.createHistory).toHaveBeenCalledTimes(
           total_songs_added
@@ -300,26 +305,3 @@ defineFeature(feature, (test) => {
     });
   });
 });
-
-// Test code for creating a new account with the given user and password
-// mockUserEntity = new UserEntity({
-//   id: "",
-//   name: user,
-//   email: "testEmail",
-//   password: password,
-//   history_tracking: true,
-//   listening_to: undefined
-// });
-
-// let expected = new UserModel(mockUserEntity as UserModel);
-
-// jest.spyOn(userService, "createUser");
-
-// await userService.createUser(mockUserEntity);
-
-// jest.spyOn(userService, "getUsers");
-
-// let users = await userService.getUsers();
-
-// expect(users).toEqual(expected);
-// await console.log(mockUserRepository.getUsers)


### PR DESCRIPTION
## Summary

Added tests for the following cases in the History service:
- Add a new song to a user history
- Delete an entry from a user history
- Clear user history
- Get user statistics

Also refactored StatisticsModel to better represent each attribute 