### PR TITLE
Add a way to disable history tracking

### DIFF
--- a/backend/src/package.json
+++ b/backend/src/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "start": "env-cmd -f .env.dev nodemon --watch src/**/*.ts --exec ts-node src/index.ts",
+    "start-linux": "env-cmd -f .env.dev nodemon --watch 'src/**/*.ts' --exec ts-node 'src/index.ts'",
     "build": "tsc -p .",
     "prod": "node dist/src/index.js",
     "test": "env-cmd -f .env.test jest --verbose --coverage  --config ./jest.config.js --detectOpenHandles",

--- a/backend/src/src/di/index.ts
+++ b/backend/src/src/di/index.ts
@@ -44,6 +44,7 @@ di.registerService(
   HistoryService,
   new HistoryService(
     di.getRepository(HistoryRepository),
+    di.getRepository(UserRepository),
     di.getRepository(SongRepository)
   )
 );

--- a/backend/src/src/repositories/base.repository.ts
+++ b/backend/src/src/repositories/base.repository.ts
@@ -31,7 +31,7 @@ export default class BaseRepository<T extends BaseEntity> {
       }
       const newItem = {
         ...data,
-        id: uuidv4(),
+        id: data.id || uuidv4(), // if id is not provided, generate a new one. careful! this will change the id of the object.
       };
       this.db.data[this.prefix].push(newItem);
       return newItem;

--- a/backend/src/tests/features/history-service.feature
+++ b/backend/src/tests/features/history-service.feature
@@ -33,3 +33,10 @@ Feature: History Service
         Then it must return the following statistics:
             | most_played_song        | most_played_genre | play_duration |
             | Never Gonna Give You Up | Rock              | 1000          |
+
+    Scenario: History Tracking disabled
+        Given the user with id "1" has history tracking disabled
+        And the user has no play history
+        When the function createHistory is called with the user_id "1" and the song_id "4"
+        And the function getUserHistory is called with the user_id "1"
+        Then the history returned must have 0 items

--- a/backend/src/tests/services/history.service.spec.ts
+++ b/backend/src/tests/services/history.service.spec.ts
@@ -6,9 +6,11 @@ import SongRepository from '../../src/repositories/song.repository';
 import SongEntity from '../../src/entities/song.entity';
 import HistoryService from '../../src/services/history.service';
 import { HttpNotFoundError } from '../../src/utils/errors/http.error';
+import UserRepository from '../../src/repositories/user.repository';
 
 describe('HistoryService', () => {
   let mockHistoryRepository: HistoryRepository;
+  let mockUserRepository: UserRepository;
   let mockSongRepository: SongRepository;
   let service: HistoryService;
 
@@ -30,11 +32,15 @@ describe('HistoryService', () => {
       deleteUserHistory: jest.fn(),
     } as any;
 
+    mockUserRepository = {
+      getUser: jest.fn(),
+    } as any;
+
     mockSongRepository = {
       getSong: jest.fn(),
     } as any;
 
-    service = new HistoryService(mockHistoryRepository, mockSongRepository);
+    service = new HistoryService(mockHistoryRepository, mockUserRepository, mockSongRepository);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Description

This PR adds a way for the user to disable history tracking.
It also allows new entries to define their own ids when creating, which facilitates testing

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 📦 Chore
- [ ] 🎨 Style
- [ ] ⏩ Revert
- [ ] 📝 Documentation

## Related Issues
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Screenshots

<!-- Visual changes require screenshots -->

## Steps to QA

"Scenario: History Tracking disabled" covers the testing for this feature
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
