### PR TITLE
Add Most Played Songs feature

### DIFF
--- a/backend/src/src/services/history.service.ts
+++ b/backend/src/src/services/history.service.ts
@@ -93,6 +93,15 @@ class HistoryService {
       }
     }
 
+    // sort by times_played then song_id
+    mostPlayedModel.sort((a, b) => {
+      if (a.times_played === b.times_played) {
+        return a.song_id.localeCompare(b.song_id);
+      } else {
+        return b.times_played - a.times_played;
+      }
+    });
+
     return mostPlayedModel;
   }
 

--- a/backend/src/tests/features/history-service.feature
+++ b/backend/src/tests/features/history-service.feature
@@ -40,3 +40,18 @@ Feature: History Service
         When the function createHistory is called with the user_id "1" and the song_id "4"
         And the function getUserHistory is called with the user_id "1"
         Then the history returned must have 0 items
+
+    Scenario: User requests most played songs
+        Given the user with id "1" has a history with the following items:
+            | times_played | song_id | title                   | artist      | genre | duration |
+            | 3            | 1       | Never Gonna Give You Up | Rick Astley | Rock  | 300      |
+            | 3            | 2       | Yellow                  | Coldplay    | Pop   | 150      |
+            | 1            | 3       | Yellow Submarine        | The Beatles | Rock  | 100      |
+            | 2            | 4       | Ticket to Ride          | The Beatles | Rock  | 250      |
+        When the function getUserMostPlayedList is called with the user_id "1"
+        Then it must return the following songs in order:
+            | song_id | title                   | artist      | genre | times_played |
+            | 1       | Never Gonna Give You Up | Rick Astley | Rock  | 3            |
+            | 2       | Yellow                  | Coldplay    | Pop   | 3            |
+            | 4       | Ticket to Ride          | The Beatles | Rock  | 2            |
+            | 3       | Yellow Submarine        | The Beatles | Rock  | 1            |

--- a/backend/src/tests/utils/history.utils.ts
+++ b/backend/src/tests/utils/history.utils.ts
@@ -1,0 +1,56 @@
+import HistoryEntity from "../../src/entities/history.entity";
+import SongEntity from "../../src/entities/song.entity";
+import HistoryRepository from "../../src/repositories/history.repository";
+import SongRepository from "../../src/repositories/song.repository";
+import HistoryService from "../../src/services/history.service";
+import SongService from "../../src/services/song.service";
+
+export const addSongsToHistory = async (
+  table: any,
+  user_id: string,
+  mockHistoryRepository: HistoryRepository,
+  mockSongRepository: SongRepository,
+  songService: SongService,
+  historyService: HistoryService
+) => {
+  let mockSongEntity;
+  let mockHistoryEntity;
+  // create songs and entries
+  jest.spyOn(mockHistoryRepository, "createHistory");
+  jest.spyOn(mockSongRepository, "createSong");
+
+  for (let row of table) {
+    // create songs
+    mockSongEntity = new SongEntity({
+      id: row.song_id,
+      title: row.title,
+      artist: row.artist,
+      duration: row.duration,
+      genre: row.genre,
+    });
+
+    let song = await songService.createSong(mockSongEntity);
+
+    // create history entries
+    mockHistoryEntity = new HistoryEntity({
+      id: "",
+      song_id: song.id,
+      user_id: user_id,
+    });
+
+    for (let i = 0; i < parseInt(row.times_played); i++) {
+      await historyService.createHistory(mockHistoryEntity);
+    }
+  }
+  expect(mockSongRepository.createSong).toHaveBeenCalledTimes(table.length);
+
+  // total_songs added should be equal to the sum of each entry on table.times_played
+  let total_songs_added = table.reduce(
+    (counter: number, row: any) => counter + parseInt(row.times_played),
+    0
+  );
+
+  expect(mockHistoryRepository.createHistory).toHaveBeenCalledTimes(
+    total_songs_added
+  );
+};


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This PR introduces a way to request the user's most played songs, in order of most listened from top to bottom.

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [X] 🧑‍💻 Refactor
- [X] ✅ Test
- [ ] 📦 Chore
- [ ] 🎨 Style
- [ ] ⏩ Revert
- [ ] 📝 Documentation

## Related Issues
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Screenshots

<!-- Visual changes require screenshots -->

## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

"Scenario: User requests most played songs" covers the test case for this feature

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
